### PR TITLE
Configure Gradle for Java 21 and Kotlin JVM 17 compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
 // for can reference in allprojects scope
 val catalog = libs
 
+val jvmTargetVersion = 17
+val javaLanguageVersion = 21
+
 allprojects {
     apply(plugin = catalog.plugins.kotlinJvm.get().pluginId)
     apply(plugin = catalog.plugins.detekt.get().pluginId)
@@ -37,5 +40,23 @@ allprojects {
                 entry.file.toString().contains("/generated/")
             }
         }
+    }
+
+    kotlin {
+        jvmToolchain {
+            languageVersion.set(JavaLanguageVersion.of(javaLanguageVersion))
+        }
+
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(jvmTargetVersion.toString()))
+        }
+    }
+
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(javaLanguageVersion))
+        }
+        targetCompatibility = JavaVersion.toVersion(jvmTargetVersion)
+        sourceCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,6 @@
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx4g
 org.gradle.configureondemand=true
+
+# setting plugin versions
+foojayResolverVersion=0.8.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,9 @@
 pluginManagement {
+    plugins {
+        val foojayResolverVersion = providers.gradleProperty("foojayResolverVersion").get()
+        id("org.gradle.toolchains.foojay-resolver-convention") version foojayResolverVersion
+    }
+
     repositories {
         gradlePluginPortal()
     }


### PR DESCRIPTION
- Added `jvmTargetVersion` and `javaLanguageVersion` constants for version control.
- Updated Gradle to use Java 21 and Kotlin JVM 17 toolchains.
- Configured `gradle.properties` to include `foojayResolverVersion` for toolchain management.
- Applied `foojay-resolver-convention` plugin in `settings.gradle.kts`.