### PR TITLE
Migrate Docker image versioning to `gradle.properties`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,7 @@ org.gradle.configureondemand=true
 
 # setting plugin versions
 foojayResolverVersion=0.8.0
+
+# Docker image
+containerImage.mysql=mysql:8.4.6
+containerImage.postgres=postgres:17.5

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,10 +12,6 @@ detekt = "1.23.8"
 ktlint = "13.0.0"
 log4j = "2.23.1"
 
-# Docker image
-containerImage-mysql = "mysql:8.4.6"
-containerImage-postgres = "postgres:17.5"
-
 [libraries]
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinxDatetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }

--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,9 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["gradle/libs.versions.toml"],
+      "managerFilePatterns": ["gradle.properties"],
       "matchStrings": [
-        "containerImage-[a-z0-9-_]+\\s*=\\s*\"(?<depName>[a-z0-9-_/]+):(?<currentValue>[a-zA-Z0-9._-]+)\""
+        "containerImage\\.[a-z0-9-_]+\\s*=\\s*(?<depName>[a-z0-9-_/]+):(?<currentValue>[a-zA-Z0-9._-]+)"
       ],
       "datasourceTemplate": "docker"
     }

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -1,3 +1,6 @@
+val containerImageMysql = rootProject.properties["containerImage.mysql"] as String
+val containerImagePostgres = rootProject.properties["containerImage.postgres"] as String
+
 dependencies {
     // Apply the kotlinx bundle of dependencies from the version catalog (`gradle/libs.versions.toml`).
     implementation(libs.bundles.kotlinxEcosystem)
@@ -23,8 +26,8 @@ val generateBuildConfig by tasks.registering {
 
             object $className {
                 object ContainerImage {
-                    const val MYSQL = "${libs.versions.containerImage.mysql.get()}"
-                    const val POSTGRESQL = "${libs.versions.containerImage.postgres.get()}"
+                    const val MYSQL = "$containerImageMysql"
+                    const val POSTGRESQL = "$containerImagePostgres"
                     // TODO: Add more container images as needed
                 }
             }


### PR DESCRIPTION
- Moved `containerImage-mysql` and `containerImage-postgres` definitions from `libs.versions.toml` to `gradle.properties`.
- Updated `renovate.json` to track Docker image versions in `gradle.properties`.
- Refactored test utilities to use properties-based Docker image configuration.