### PR TITLE
Add data generation framework for Maigreko

### DIFF
--- a/core/src/main/kotlin/momosetkn/maigreko/data/BaseDataGenerator.kt
+++ b/core/src/main/kotlin/momosetkn/maigreko/data/BaseDataGenerator.kt
@@ -1,0 +1,298 @@
+package momosetkn.maigreko.data
+
+import momosetkn.maigreko.change.AddColumn
+import momosetkn.maigreko.change.AddForeignKey
+import momosetkn.maigreko.change.AddIndex
+import momosetkn.maigreko.change.AddNotNullConstraint
+import momosetkn.maigreko.change.AddUniqueConstraint
+import momosetkn.maigreko.change.Change
+import momosetkn.maigreko.change.Column
+import momosetkn.maigreko.change.CreateSequence
+import momosetkn.maigreko.change.CreateTable
+import momosetkn.maigreko.change.ModifyDataType
+import momosetkn.maigreko.change.RenameColumn
+import momosetkn.maigreko.change.RenameTable
+import momosetkn.maigreko.introspector.Introspector
+
+/**
+ * Base implementation of DataGenerator that provides common functionality
+ * for processing Change objects into DatabaseData structures.
+ * Database-specific implementations can extend this class and override
+ * methods for dialect-specific behavior.
+ */
+interface BaseDataGenerator : DataGenerator {
+    val introspector: Introspector
+
+    /**
+     * Generates database-specific data from a list of Change objects.
+     * This base implementation extracts common database elements like tables,
+     * indexes, constraints, and sequences from the Change objects.
+     *
+     * @param changes List of Change objects to process
+     * @return Generated DatabaseData containing processed information
+     */
+    override fun generateData(changes: List<Change>): DatabaseData {
+        val tables = extractTables(changes)
+        val indexes = extractIndexes(changes)
+        val constraints = extractConstraints(changes)
+        val sequences = extractSequences(changes)
+        val statements = generateStatements(changes)
+        val metadata = generateMetadata(changes)
+
+        return DatabaseData(
+            sourceChanges = changes,
+            metadata = metadata,
+            statements = statements,
+            tables = tables,
+            indexes = indexes,
+            constraints = constraints,
+            sequences = sequences
+        )
+    }
+
+    /**
+     * Extracts table information from Change objects.
+     * Processes CreateTable and AddColumn changes to build table structures.
+     *
+     * @param changes List of Change objects
+     * @return List of TableInfo objects
+     */
+    fun extractTables(changes: List<Change>): List<TableInfo> {
+        val tables = mutableMapOf<String, MutableList<ColumnInfo>>()
+
+        changes.forEach { change ->
+            when (change) {
+                is CreateTable -> {
+                    val columns = change.columns.map { column ->
+                        ColumnInfo(
+                            name = column.name,
+                            type = column.type,
+                            nullable = column.columnConstraint?.nullable ?: true,
+                            defaultValue = column.defaultValue,
+                            autoIncrement = column.autoIncrement,
+                            metadata = buildColumnMetadata(column)
+                        )
+                    }
+                    tables[change.tableName] = columns.toMutableList()
+                }
+                is AddColumn -> {
+                    val column = change.column
+                    val columnInfo = ColumnInfo(
+                        name = column.name,
+                        type = column.type,
+                        nullable = column.columnConstraint?.nullable ?: true,
+                        defaultValue = column.defaultValue,
+                        autoIncrement = column.autoIncrement,
+                        metadata = buildColumnMetadata(column)
+                    )
+                    tables.getOrPut(change.tableName) { mutableListOf() }.add(columnInfo)
+                }
+                else -> { /* Ignore other change types for table extraction */ }
+            }
+        }
+
+        return tables.map { (tableName, columns) ->
+            TableInfo(
+                name = tableName,
+                columns = columns,
+                metadata = buildTableMetadata(tableName, changes)
+            )
+        }
+    }
+
+    /**
+     * Extracts index information from Change objects.
+     *
+     * @param changes List of Change objects
+     * @return List of IndexInfo objects
+     */
+    fun extractIndexes(changes: List<Change>): List<IndexInfo> {
+        return changes.filterIsInstance<AddIndex>().map { change ->
+            IndexInfo(
+                name = change.indexName,
+                tableName = change.tableName,
+                columns = change.columnNames,
+                unique = change.unique,
+                metadata = buildIndexMetadata(change)
+            )
+        }
+    }
+
+    /**
+     * Extracts constraint information from Change objects.
+     *
+     * @param changes List of Change objects
+     * @return List of ConstraintInfo objects
+     */
+    fun extractConstraints(changes: List<Change>): List<ConstraintInfo> {
+        val constraints = mutableListOf<ConstraintInfo>()
+
+        changes.forEach { change ->
+            when (change) {
+                is AddForeignKey -> {
+                    constraints.add(
+                        ConstraintInfo(
+                            name = change.constraintName,
+                            type = ConstraintType.FOREIGN_KEY,
+                            tableName = change.tableName,
+                            columns = change.columnNames,
+                            referencedTable = change.referencedTableName,
+                            referencedColumns = change.referencedColumnNames,
+                            metadata = buildForeignKeyMetadata(change)
+                        )
+                    )
+                }
+                is AddUniqueConstraint -> {
+                    constraints.add(
+                        ConstraintInfo(
+                            name = change.constraintName,
+                            type = ConstraintType.UNIQUE,
+                            tableName = change.tableName,
+                            columns = change.columnNames,
+                            metadata = buildUniqueConstraintMetadata(change)
+                        )
+                    )
+                }
+                is AddNotNullConstraint -> {
+                    constraints.add(
+                        ConstraintInfo(
+                            name = "${change.tableName}_${change.columnName}_not_null",
+                            type = ConstraintType.NOT_NULL,
+                            tableName = change.tableName,
+                            columns = listOf(change.columnName),
+                            metadata = buildNotNullConstraintMetadata(change)
+                        )
+                    )
+                }
+                is CreateTable -> {
+                    // Extract primary key and other constraints from table columns
+                    change.columns.forEach { column ->
+                        column.columnConstraint?.let { constraint ->
+                            if (constraint.primaryKey) {
+                                constraints.add(
+                                    ConstraintInfo(
+                                        name = "${change.tableName}_${column.name}_pk",
+                                        type = ConstraintType.PRIMARY_KEY,
+                                        tableName = change.tableName,
+                                        columns = listOf(column.name),
+                                        metadata = buildPrimaryKeyMetadata(change, column)
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+                else -> { /* Ignore other change types for constraint extraction */ }
+            }
+        }
+
+        return constraints
+    }
+
+    /**
+     * Extracts sequence information from Change objects.
+     *
+     * @param changes List of Change objects
+     * @return List of SequenceInfo objects
+     */
+    fun extractSequences(changes: List<Change>): List<SequenceInfo> {
+        return changes.filterIsInstance<CreateSequence>().map { change ->
+            SequenceInfo(
+                name = change.sequenceName,
+                dataType = change.dataType,
+                startValue = change.startValue,
+                incrementBy = change.incrementBy,
+                minValue = change.minValue,
+                maxValue = change.maxValue,
+                cycle = change.cycle,
+                metadata = buildSequenceMetadata(change)
+            )
+        }
+    }
+
+    /**
+     * Generates SQL statements or other database commands from Change objects.
+     * This base implementation returns empty list - subclasses should override for dialect-specific SQL generation.
+     *
+     * @param changes List of Change objects
+     * @return List of SQL statements or commands
+     */
+    fun generateStatements(changes: List<Change>): List<String> {
+        return emptyList()
+    }
+
+    /**
+     * Generates general metadata about the processed changes.
+     *
+     * @param changes List of Change objects
+     * @return Map of metadata key-value pairs
+     */
+    fun generateMetadata(changes: List<Change>): Map<String, Any> {
+        val changeTypeCounts = changes.groupBy { it::class.simpleName }.mapValues { it.value.size }
+        return mapOf(
+            "totalChanges" to changes.size,
+            "changeTypeCounts" to changeTypeCounts,
+            "generatedAt" to System.currentTimeMillis()
+        )
+    }
+
+    // Metadata building methods - can be overridden by subclasses for dialect-specific metadata
+
+    fun buildColumnMetadata(column: Column): Map<String, Any> {
+        val metadata = mutableMapOf<String, Any>()
+        column.identityGeneration?.let { metadata["identityGeneration"] = it }
+        column.startValue?.let { metadata["startValue"] = it }
+        column.incrementBy?.let { metadata["incrementBy"] = it }
+        column.cycle?.let { metadata["cycle"] = it }
+        column.individualObject?.let { metadata["individualObject"] = it }
+        return metadata
+    }
+
+    fun buildTableMetadata(tableName: String, changes: List<Change>): Map<String, Any> {
+        val tableChanges = changes.filter { change ->
+            when (change) {
+                is CreateTable -> change.tableName == tableName
+                is AddColumn -> change.tableName == tableName
+                is RenameTable -> change.oldTableName == tableName || change.newTableName == tableName
+                is RenameColumn -> change.tableName == tableName
+                is ModifyDataType -> change.tableName == tableName
+                is AddNotNullConstraint -> change.tableName == tableName
+                is AddForeignKey -> change.tableName == tableName
+                is AddUniqueConstraint -> change.tableName == tableName
+                is AddIndex -> change.tableName == tableName
+                else -> false
+            }
+        }
+        return mapOf("relatedChanges" to tableChanges.size)
+    }
+
+    fun buildIndexMetadata(change: AddIndex): Map<String, Any> = emptyMap()
+
+    fun buildForeignKeyMetadata(change: AddForeignKey): Map<String, Any> {
+        val metadata = mutableMapOf<String, Any>()
+        change.onDelete?.let { metadata["onDelete"] = it }
+        change.onUpdate?.let { metadata["onUpdate"] = it }
+        metadata["deferrable"] = change.deferrable
+        metadata["initiallyDeferred"] = change.initiallyDeferred
+        return metadata
+    }
+
+    fun buildUniqueConstraintMetadata(change: AddUniqueConstraint): Map<String, Any> = emptyMap()
+
+    fun buildNotNullConstraintMetadata(change: AddNotNullConstraint): Map<String, Any> {
+        val metadata = mutableMapOf<String, Any>()
+        metadata["columnDataType"] = change.columnDataType
+        change.defaultValue?.let { metadata["defaultValue"] = it }
+        return metadata
+    }
+
+    fun buildPrimaryKeyMetadata(change: CreateTable, column: Column): Map<String, Any> = emptyMap()
+
+    fun buildSequenceMetadata(change: CreateSequence): Map<String, Any> {
+        val metadata = mutableMapOf<String, Any>()
+        change.generatedKind?.let { metadata["generatedKind"] = it }
+        change.identityGeneration?.let { metadata["identityGeneration"] = it }
+        change.cacheSize?.let { metadata["cacheSize"] = it }
+        return metadata
+    }
+}

--- a/core/src/main/kotlin/momosetkn/maigreko/data/BaseRecordDataGenerator.kt
+++ b/core/src/main/kotlin/momosetkn/maigreko/data/BaseRecordDataGenerator.kt
@@ -1,0 +1,249 @@
+package momosetkn.maigreko.data
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+// import kotlin.random.Random
+
+/**
+ * Base implementation of RecordDataGenerator that provides common functionality
+ * for generating database record data. Database-specific implementations can extend
+ * this class and override methods for dialect-specific behavior.
+ */
+open class BaseRecordDataGenerator : RecordDataGenerator {
+    override fun generateRecords(
+        tables: List<TableInfo>,
+        config: RecordGenerationConfig
+    ): Map<String, RecordData> {
+        val result = mutableMapOf<String, RecordData>()
+
+        // Sort tables to handle foreign key dependencies
+        val sortedTables = if (config.respectForeignKeys) {
+            sortTablesByDependencies(tables)
+        } else {
+            tables
+        }
+
+        for (table in sortedTables) {
+            result[table.name] = generateRecords(table, config)
+        }
+
+        return result
+    }
+
+    override fun generateRecords(
+        table: TableInfo,
+        config: RecordGenerationConfig
+    ): RecordData {
+        val records = mutableListOf<Map<String, Any?>>()
+
+        repeat(config.recordsPerTable) { recordIndex ->
+            val record = mutableMapOf<String, Any?>()
+
+            for (column in table.columns) {
+                val value = generateValueForColumn(column, record, config, recordIndex)
+                record[column.name] = value
+            }
+
+            records.add(record)
+        }
+
+        return RecordData(
+            tableName = table.name,
+            records = records,
+            metadata = mapOf(
+                "generatedAt" to System.currentTimeMillis(),
+                "recordCount" to records.size,
+                "config" to config
+            )
+        )
+    }
+
+    /**
+     * Generates a value for a specific column based on its type and constraints.
+     */
+    protected open fun generateValueForColumn(
+        column: ColumnInfo,
+        currentRecord: Map<String, Any?>,
+        config: RecordGenerationConfig,
+        recordIndex: Int,
+        setNull: Boolean,
+    ): Any? {
+        // Check for custom generator first
+        val customGenerator = config.customGenerators[column.name]
+            ?: config.customGenerators[column.type.lowercase()]
+
+        if (customGenerator != null) {
+            return customGenerator.generate(column, currentRecord)
+        }
+
+        // Handle nullable columns
+        if (column.nullable && setNull) {
+            return null
+        }
+
+        // Handle auto-increment columns
+        if (column.autoIncrement) {
+            return recordIndex + 1L
+        }
+
+        // Generate value based on column type
+        return generateValueByType(column.name, column.type, recordIndex)
+    }
+
+    /**
+     * Generates a value based on the column's data type.
+     */
+    protected open fun generateValueByType(columnName: String, type: String, recordIndex: Int): Any? {
+        val lowerType = type.lowercase()
+
+        return when {
+            // Integer types
+            lowerType.contains("int") || lowerType.contains("number") -> {
+                when {
+                    lowerType.contains("bigint") || lowerType.contains("long") -> random.nextLong(1, 1000000)
+                    lowerType.contains("smallint") || lowerType.contains("short") -> random.nextInt(1, 32767)
+                    lowerType.contains("tinyint") || lowerType.contains("byte") -> random.nextInt(1, 255)
+                    else -> random.nextInt(1, 100000)
+                }
+            }
+
+            // Decimal/Float types
+            lowerType.contains("decimal") || lowerType.contains("numeric") ||
+                lowerType.contains("float") || lowerType.contains("double") ||
+                lowerType.contains("real") -> {
+                (random.nextDouble() * 10000).toBigDecimal().setScale(2, java.math.RoundingMode.HALF_UP)
+            }
+
+            // String/Text types
+            lowerType.contains("varchar") || lowerType.contains("char") ||
+                lowerType.contains("text") || lowerType.contains("string") -> {
+                generateStringValue(columnName, lowerType, random, recordIndex)
+            }
+
+            // Date/Time types
+            lowerType.contains("date") || lowerType.contains("time") || lowerType.contains("timestamp") -> {
+                generateDateTimeValue(lowerType, random)
+            }
+
+            // Boolean types
+            lowerType.contains("bool") || lowerType.contains("bit") -> {
+                random.nextBoolean()
+            }
+
+            // Binary types
+            lowerType.contains("blob") || lowerType.contains("binary") || lowerType.contains("bytea") -> {
+                random.nextBytes(random.nextInt(10, 100))
+            }
+
+            // UUID types
+            lowerType.contains("uuid") || lowerType.contains("guid") -> {
+                java.util.UUID.randomUUID().toString()
+            }
+
+            // JSON types
+            lowerType.contains("json") -> {
+                """{"id": ${recordIndex + 1}, "data": "sample_data_${random.nextInt(1000)}"}"""
+            }
+
+            // Default fallback
+            else -> "generated_value_${recordIndex + 1}"
+        }
+    }
+
+    /**
+     * Generates string values based on column name patterns and constraints.
+     */
+    protected open fun generateStringValue(columnName: String, type: String, random: Random, recordIndex: Int): String {
+        val maxLength = extractMaxLength(type) ?: 50
+
+        return when {
+            columnName.contains("email", ignoreCase = true) -> generateEmail(random)
+            columnName.contains("name", ignoreCase = true) -> generateName(random)
+            columnName.contains("address", ignoreCase = true) -> generateAddress(random)
+            columnName.contains("phone", ignoreCase = true) -> generatePhone(random)
+            type.contains("email") -> generateEmail(random)
+            type.contains("name") -> generateName(random)
+            type.contains("address") -> generateAddress(random)
+            type.contains("phone") -> generatePhone(random)
+            else -> generateRandomString(maxLength, random, recordIndex)
+        }
+    }
+
+    /**
+     * Generates date/time values based on the specific type.
+     */
+    protected open fun generateDateTimeValue(type: String, random: Random): Any {
+        val now = System.currentTimeMillis()
+        val randomOffset = random.nextLong(-365 * 24 * 60 * 60 * 1000L, 365 * 24 * 60 * 60 * 1000L)
+        val timestamp = now + randomOffset
+
+        return when {
+            type.contains("timestamp") -> java.sql.Timestamp(timestamp)
+            type.contains("date") -> java.sql.Date(timestamp)
+            type.contains("time") -> java.sql.Time(timestamp % (24 * 60 * 60 * 1000))
+            else -> java.sql.Timestamp(timestamp)
+        }
+    }
+
+    /**
+     * Sorts tables to respect foreign key dependencies.
+     * Tables with no dependencies come first.
+     */
+    protected open fun sortTablesByDependencies(tables: List<TableInfo>): List<TableInfo> {
+        // For now, return tables as-is. In a full implementation, this would
+        // analyze foreign key constraints and sort accordingly.
+        return tables
+    }
+
+    // Utility methods for generating specific types of data
+
+    private fun extractMaxLength(type: String): Int? {
+        val regex = """.*\((\d+)\).*""".toRegex()
+        return regex.find(type)?.groupValues?.get(1)?.toIntOrNull()
+    }
+
+    private fun generateRandomString(maxLength: Int, recordIndex: Int): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+        if (maxLength <= 10) {
+            // For short lengths, generate simple string
+            return buildString {
+                repeat(maxLength) {
+                    append(chars.random(random))
+                }
+            }
+        }
+
+        val length = minOf(maxLength, AutoData.nextInt(5, 20))
+        val prefix = "gen_${recordIndex + 1}_"
+        val remainingLength = maxOf(0, length - prefix.length)
+
+        return buildString {
+            append(prefix)
+            repeat(remainingLength) {
+                append(chars.random(random))
+            }
+        }.take(maxLength)
+    }
+}
+
+object AutoData {
+    var currentUuidNum = 0
+
+    inline fun <reified T> nextValue(): T {
+        return when (T::class) {
+            Int::class -> currentUuidNum++
+            Long::class -> (currentUuidNum++).toLong()
+            Double::class -> currentUuidNum++ / 10.0
+            String::class -> "str" + currentUuidNum++
+            LocalDate::class -> LocalDate.now().plusDays(currentUuidNum++.toLong())
+            LocalDateTime::class -> LocalDateTime.now().withNano(0).plusHours(currentUuidNum++.toLong())
+            else -> throw NotImplementedError("not supported ${T::class} type")
+        } as T
+    }
+
+    fun nextInt(min: Int = 0, max: Int = Int.MAX_VALUE): Int {
+        return nextValue<Int>() % (max - min + 1) + min
+    }
+}

--- a/core/src/main/kotlin/momosetkn/maigreko/data/DataGenerator.kt
+++ b/core/src/main/kotlin/momosetkn/maigreko/data/DataGenerator.kt
@@ -1,0 +1,18 @@
+package momosetkn.maigreko.data
+
+import momosetkn.maigreko.change.Change
+
+/**
+ * Interface for generating database-specific data from Change objects.
+ * This interface defines the contract for converting Change objects
+ * into database-specific data structures or formats.
+ */
+interface DataGenerator {
+    /**
+     * Generates database-specific data from a list of Change objects.
+     *
+     * @param changes List of Change objects to process
+     * @return Generated database-specific data
+     */
+    fun generateData(changes: List<Change>): DatabaseData
+}

--- a/core/src/main/kotlin/momosetkn/maigreko/data/DatabaseData.kt
+++ b/core/src/main/kotlin/momosetkn/maigreko/data/DatabaseData.kt
@@ -1,0 +1,115 @@
+package momosetkn.maigreko.data
+
+import momosetkn.maigreko.change.Change
+
+/**
+ * Represents database-specific data generated from Change objects.
+ * This class contains processed and transformed data that can be used
+ * for various database operations and reporting.
+ */
+data class DatabaseData(
+    /**
+     * The original Change objects that were processed
+     */
+    val sourceChanges: List<Change>,
+
+    /**
+     * Database-specific metadata extracted from the changes
+     */
+    val metadata: Map<String, Any> = emptyMap(),
+
+    /**
+     * Generated SQL statements or other database commands
+     */
+    val statements: List<String> = emptyList(),
+
+    /**
+     * Table information extracted from the changes
+     */
+    val tables: List<TableInfo> = emptyList(),
+
+    /**
+     * Index information extracted from the changes
+     */
+    val indexes: List<IndexInfo> = emptyList(),
+
+    /**
+     * Constraint information extracted from the changes
+     */
+    val constraints: List<ConstraintInfo> = emptyList(),
+
+    /**
+     * Sequence information extracted from the changes
+     */
+    val sequences: List<SequenceInfo> = emptyList()
+)
+
+/**
+ * Represents table information extracted from Change objects
+ */
+data class TableInfo(
+    val name: String,
+    val columns: List<ColumnInfo>,
+    val metadata: Map<String, Any> = emptyMap()
+)
+
+/**
+ * Represents column information
+ */
+data class ColumnInfo(
+    val name: String,
+    val type: String,
+    val nullable: Boolean = true,
+    val defaultValue: Any? = null,
+    val autoIncrement: Boolean = false,
+    val metadata: Map<String, Any> = emptyMap()
+)
+
+/**
+ * Represents index information
+ */
+data class IndexInfo(
+    val name: String,
+    val tableName: String,
+    val columns: List<String>,
+    val unique: Boolean = false,
+    val metadata: Map<String, Any> = emptyMap()
+)
+
+/**
+ * Represents constraint information
+ */
+data class ConstraintInfo(
+    val name: String,
+    val type: ConstraintType,
+    val tableName: String,
+    val columns: List<String>,
+    val referencedTable: String? = null,
+    val referencedColumns: List<String> = emptyList(),
+    val metadata: Map<String, Any> = emptyMap()
+)
+
+/**
+ * Types of database constraints
+ */
+enum class ConstraintType {
+    PRIMARY_KEY,
+    FOREIGN_KEY,
+    UNIQUE,
+    CHECK,
+    NOT_NULL
+}
+
+/**
+ * Represents sequence information
+ */
+data class SequenceInfo(
+    val name: String,
+    val dataType: String? = null,
+    val startValue: Long? = null,
+    val incrementBy: Long? = null,
+    val minValue: Long? = null,
+    val maxValue: Long? = null,
+    val cycle: Boolean = false,
+    val metadata: Map<String, Any> = emptyMap()
+)

--- a/core/src/main/kotlin/momosetkn/maigreko/data/RecordData.kt
+++ b/core/src/main/kotlin/momosetkn/maigreko/data/RecordData.kt
@@ -1,0 +1,71 @@
+package momosetkn.maigreko.data
+
+/**
+ * Represents generated database record data.
+ * This class contains actual data records that can be inserted into database tables.
+ */
+data class RecordData(
+    /**
+     * The table name this record data belongs to
+     */
+    val tableName: String,
+
+    /**
+     * List of records, where each record is a map of column name to value
+     */
+    val records: List<Map<String, Any?>>,
+
+    /**
+     * Metadata about the record generation
+     */
+    val metadata: Map<String, Any> = emptyMap()
+)
+
+/**
+ * Configuration for generating record data
+ */
+data class RecordGenerationConfig(
+    /**
+     * Number of records to generate per table
+     */
+    val recordsPerTable: Int = 10,
+
+    /**
+     * Seed for random data generation (for reproducible results)
+     */
+    val seed: Long? = null,
+
+    /**
+     * Locale for generating localized data (names, addresses, etc.)
+     */
+    val locale: String = "en_US",
+
+    /**
+     * Whether to respect foreign key constraints when generating data
+     */
+    val respectForeignKeys: Boolean = true,
+
+    /**
+     * Custom value generators for specific columns or data types
+     */
+    val customGenerators: Map<String, ValueGenerator> = emptyMap(),
+
+    /**
+     * Additional configuration options
+     */
+    val options: Map<String, Any> = emptyMap()
+)
+
+/**
+ * Interface for generating values for specific data types or columns
+ */
+interface ValueGenerator {
+    /**
+     * Generates a value for the specified column
+     *
+     * @param columnInfo Information about the column
+     * @param context Generation context (e.g., other column values in the same record)
+     * @return Generated value
+     */
+    fun generate(columnInfo: ColumnInfo, context: Map<String, Any?> = emptyMap()): Any?
+}

--- a/core/src/main/kotlin/momosetkn/maigreko/data/RecordDataGenerator.kt
+++ b/core/src/main/kotlin/momosetkn/maigreko/data/RecordDataGenerator.kt
@@ -1,0 +1,30 @@
+package momosetkn.maigreko.data
+
+/**
+ * Interface for generating database record data from table structures.
+ */
+interface RecordDataGenerator {
+    /**
+     * Generates record data for the specified tables.
+     *
+     * @param tables List of table information to generate data for
+     * @param config Configuration for record generation
+     * @return Map of table name to generated record data
+     */
+    fun generateRecords(
+        tables: List<TableInfo>,
+        config: RecordGenerationConfig = RecordGenerationConfig()
+    ): Map<String, RecordData>
+
+    /**
+     * Generates record data for a single table.
+     *
+     * @param table Table information to generate data for
+     * @param config Configuration for record generation
+     * @return Generated record data for the table
+     */
+    fun generateRecords(
+        table: TableInfo,
+        config: RecordGenerationConfig = RecordGenerationConfig()
+    ): RecordData
+}

--- a/core/src/main/kotlin/momosetkn/maigreko/data/RecordDataGeneratorBuilder.kt
+++ b/core/src/main/kotlin/momosetkn/maigreko/data/RecordDataGeneratorBuilder.kt
@@ -1,0 +1,28 @@
+package momosetkn.maigreko.data
+
+import momosetkn.maigreko.introspector.Introspector
+import javax.sql.DataSource
+
+/**
+ * Builder interface for creating RecordDataGenerator instances.
+ * Implementations of this interface are discovered using Java's ServiceLoader mechanism.
+ * Each database dialect should provide its own implementation if needed.
+ */
+interface RecordDataGeneratorBuilder {
+    /**
+     * The name of this builder, typically the database dialect name.
+     * Used for matching against database types.
+     *
+     * @return The name of this builder (e.g., "postgresql", "mysql", etc.)
+     */
+    val name: String
+
+    /**
+     * Creates a RecordDataGenerator instance for the specific database dialect.
+     *
+     * @param introspector The Introspector instance to use for database introspection (optional)
+     * @param dataSource The DataSource for database connections (optional)
+     * @return A RecordDataGenerator instance for the specific dialect
+     */
+    fun build(introspector: Introspector? = null, dataSource: DataSource? = null): RecordDataGenerator
+}

--- a/core/src/main/kotlin/momosetkn/maigreko/data/RecordDataGeneratorFactory.kt
+++ b/core/src/main/kotlin/momosetkn/maigreko/data/RecordDataGeneratorFactory.kt
@@ -1,0 +1,203 @@
+package momosetkn.maigreko.data
+
+import momosetkn.maigreko.introspector.Introspector
+import java.sql.DatabaseMetaData
+import java.sql.SQLException
+import java.util.ServiceLoader
+import javax.sql.DataSource
+
+/**
+ * Factory for creating RecordDataGenerator instances.
+ * Uses Java's ServiceLoader mechanism to discover RecordDataGenerator implementations
+ * and automatically detects the appropriate dialect from database metadata.
+ */
+object RecordDataGeneratorFactory {
+    /**
+     * Creates a RecordDataGenerator instance based on database metadata.
+     * Automatically detects the appropriate dialect from the database connection.
+     *
+     * @param dataSource The DataSource to use for database connections
+     * @return A RecordDataGenerator instance for the detected dialect
+     * @throws IllegalArgumentException if no RecordDataGenerator is found for the detected dialect
+     * @throws SQLException if there is an error accessing the database metadata
+     */
+    fun create(dataSource: DataSource): RecordDataGenerator {
+        dataSource.connection.use { connection ->
+            val metadata = connection.metaData
+            val dialect = getDialectByMetaData(metadata)
+
+            return dialect?.let { create(it, dataSource) } ?: createFirst(dataSource)
+        }
+    }
+
+    /**
+     * Creates a RecordDataGenerator instance for the specified dialect.
+     *
+     * @param dialect The database dialect to create a RecordDataGenerator for
+     * @param dataSource The DataSource to use for database connections
+     * @return A RecordDataGenerator instance for the specified dialect
+     * @throws IllegalArgumentException if no RecordDataGenerator is found for the specified dialect
+     */
+    fun create(dialect: String, dataSource: DataSource): RecordDataGenerator {
+        // Try to find a builder for the dialect
+        val builderLoader = ServiceLoader.load(RecordDataGeneratorBuilder::class.java)
+        val builders = builderLoader.iterator()
+
+        while (builders.hasNext()) {
+            val builder = builders.next()
+            if (builder.name.startsWith(dialect.lowercase())) {
+                return builder.build(dataSource = dataSource)
+            }
+        }
+
+        // If no dialect-specific builder found, return base implementation
+        return BaseRecordDataGenerator()
+    }
+
+    /**
+     * Creates a RecordDataGenerator instance using an existing Introspector.
+     * Attempts to detect the dialect from the DataSource if provided.
+     *
+     * @param introspector The Introspector instance to use
+     * @param dataSource The DataSource for database connections (optional)
+     * @return A RecordDataGenerator instance
+     * @throws IllegalArgumentException if no RecordDataGenerator implementation is found
+     */
+    fun create(introspector: Introspector, dataSource: DataSource? = null): RecordDataGenerator {
+        if (dataSource != null) {
+            // Try to detect dialect and create specific RecordDataGenerator
+            try {
+                dataSource.connection.use { connection ->
+                    val metadata = connection.metaData
+                    val dialect = getDialectByMetaData(metadata)
+                    if (dialect != null) {
+                        return create(dialect, introspector, dataSource)
+                    }
+                }
+            } catch (e: SQLException) {
+                // Fall back to generic approach if metadata access fails
+            }
+        }
+
+        // Fall back to first available RecordDataGenerator
+        return createFirst(introspector, dataSource)
+    }
+
+    /**
+     * Creates a RecordDataGenerator instance for the specified dialect using an existing Introspector.
+     *
+     * @param dialect The database dialect
+     * @param introspector The Introspector instance to use
+     * @param dataSource The DataSource for database connections (optional)
+     * @return A RecordDataGenerator instance for the specified dialect
+     * @throws IllegalArgumentException if no RecordDataGenerator is found for the specified dialect
+     */
+    fun create(dialect: String, introspector: Introspector, dataSource: DataSource? = null): RecordDataGenerator {
+        val builderLoader = ServiceLoader.load(RecordDataGeneratorBuilder::class.java)
+        val builders = builderLoader.iterator()
+
+        while (builders.hasNext()) {
+            val builder = builders.next()
+            if (builder.name.startsWith(dialect.lowercase())) {
+                return builder.build(introspector, dataSource)
+            }
+        }
+
+        // If no dialect-specific builder found, return base implementation
+        return BaseRecordDataGenerator()
+    }
+
+    /**
+     * Creates a RecordDataGenerator instance by loading the first available implementation
+     * from ServiceLoader, or returns the base implementation if none found.
+     *
+     * @param dataSource The DataSource to use for database connections
+     * @return A RecordDataGenerator instance
+     */
+    fun createFirst(dataSource: DataSource): RecordDataGenerator {
+        val builderLoader = ServiceLoader.load(RecordDataGeneratorBuilder::class.java)
+        val builders = builderLoader.iterator()
+
+        if (builders.hasNext()) {
+            val builder = builders.next()
+            return builder.build(dataSource = dataSource)
+        }
+
+        // Fall back to base implementation
+        return BaseRecordDataGenerator()
+    }
+
+    /**
+     * Creates a RecordDataGenerator instance by loading the first available implementation
+     * from ServiceLoader using an existing Introspector.
+     *
+     * @param introspector The Introspector instance to use
+     * @param dataSource The DataSource for database connections (optional)
+     * @return A RecordDataGenerator instance
+     */
+    fun createFirst(introspector: Introspector? = null, dataSource: DataSource? = null): RecordDataGenerator {
+        val builderLoader = ServiceLoader.load(RecordDataGeneratorBuilder::class.java)
+        val builders = builderLoader.iterator()
+
+        if (builders.hasNext()) {
+            val builder = builders.next()
+            return builder.build(introspector, dataSource)
+        }
+
+        // Fall back to base implementation
+        return BaseRecordDataGenerator()
+    }
+
+    /**
+     * Creates a RecordDataGenerator that can work with DatabaseData from the existing data generation system.
+     * This method integrates with the existing DataGenerator to provide record generation capabilities.
+     *
+     * @param databaseData The DatabaseData containing table structures
+     * @param config Configuration for record generation
+     * @return Map of table name to generated record data
+     */
+    fun generateRecords(
+        databaseData: DatabaseData,
+        config: RecordGenerationConfig = RecordGenerationConfig()
+    ): Map<String, RecordData> {
+        val generator = BaseRecordDataGenerator()
+        return generator.generateRecords(databaseData.tables, config)
+    }
+
+    @Suppress("ComplexMethod")
+    private fun getDialectByMetaData(metadata: DatabaseMetaData): String? {
+        // Try to determine dialect from database product name
+        val productName = metadata.databaseProductName
+        val driverName = metadata.driverName
+        val url = metadata.url
+
+        // Try to match by product name first
+        val dialect = when {
+            productName.contains("PostgreSQL", ignoreCase = true) -> "postgresql"
+            productName.contains("MySQL", ignoreCase = true) -> "mysql"
+            productName.contains("Oracle", ignoreCase = true) -> "oracle"
+            productName.contains("H2", ignoreCase = true) -> "h2"
+            productName.contains("MariaDB", ignoreCase = true) -> "mariadb"
+            productName.contains("Microsoft SQL Server", ignoreCase = true) -> "sqlserver"
+            // If product name doesn't match, try URL
+            url.contains("postgresql", ignoreCase = true) -> "postgresql"
+            url.contains("mysql", ignoreCase = true) -> "mysql"
+            url.contains("oracle", ignoreCase = true) -> "oracle"
+            url.contains("h2", ignoreCase = true) -> "h2"
+            url.contains("mariadb", ignoreCase = true) -> "mariadb"
+            url.contains("sqlserver", ignoreCase = true) -> "sqlserver"
+            url.contains("jdbc:microsoft:sqlserver", ignoreCase = true) -> "sqlserver"
+            // If URL doesn't match, try driver name
+            driverName.contains("PostgreSQL", ignoreCase = true) -> "postgresql"
+            driverName.contains("MySQL", ignoreCase = true) -> "mysql"
+            driverName.contains("Oracle", ignoreCase = true) -> "oracle"
+            driverName.contains("H2", ignoreCase = true) -> "h2"
+            driverName.contains("MariaDB", ignoreCase = true) -> "mariadb"
+            driverName.contains("SQLServer", ignoreCase = true) -> "sqlserver"
+            driverName.contains("Microsoft JDBC Driver", ignoreCase = true) -> "sqlserver"
+            // Default case
+            else -> null
+        }
+        return dialect
+    }
+}

--- a/core/src/test/kotlin/momosetkn/maigreko/data/BaseDataGeneratorSpec.kt
+++ b/core/src/test/kotlin/momosetkn/maigreko/data/BaseDataGeneratorSpec.kt
@@ -1,0 +1,306 @@
+package momosetkn.maigreko.data
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import momosetkn.maigreko.change.AddColumn
+import momosetkn.maigreko.change.AddForeignKey
+import momosetkn.maigreko.change.AddIndex
+import momosetkn.maigreko.change.AddNotNullConstraint
+import momosetkn.maigreko.change.AddUniqueConstraint
+import momosetkn.maigreko.change.Change
+import momosetkn.maigreko.change.Column
+import momosetkn.maigreko.change.ColumnConstraint
+import momosetkn.maigreko.change.CreateSequence
+import momosetkn.maigreko.change.CreateTable
+import momosetkn.maigreko.change.ForeignKeyAction
+import momosetkn.maigreko.introspector.Introspector
+
+class BaseDataGeneratorSpec : FunSpec({
+
+    context("BaseDataGenerator") {
+        val mockIntrospector = object : Introspector {
+            override fun introspect(): List<Change> = emptyList()
+        }
+
+        val generator = BaseDataGenerator(mockIntrospector)
+
+        test("should generate empty DatabaseData for empty change list") {
+            val changes = emptyList<Change>()
+            val result = generator.generateData(changes)
+
+            result.sourceChanges shouldBe changes
+            result.tables shouldHaveSize 0
+            result.indexes shouldHaveSize 0
+            result.constraints shouldHaveSize 0
+            result.sequences shouldHaveSize 0
+            result.statements shouldHaveSize 0
+            result.metadata["totalChanges"] shouldBe 0
+        }
+
+        test("should extract table information from CreateTable change") {
+            val columns = listOf(
+                Column.build(
+                    name = "id",
+                    type = "INTEGER",
+                    columnConstraint = ColumnConstraint(primaryKey = true, nullable = false)
+                ),
+                Column.build(
+                    name = "name",
+                    type = "VARCHAR(100)",
+                    columnConstraint = ColumnConstraint(nullable = false)
+                )
+            )
+
+            val changes = listOf(
+                CreateTable(
+                    tableName = "users",
+                    columns = columns
+                )
+            )
+
+            val result = generator.generateData(changes)
+
+            result.tables shouldHaveSize 1
+            val table = result.tables.first()
+            table.name shouldBe "users"
+            table.columns shouldHaveSize 2
+
+            val idColumn = table.columns.find { it.name == "id" }!!
+            idColumn.type shouldBe "INTEGER"
+            idColumn.nullable shouldBe false
+
+            val nameColumn = table.columns.find { it.name == "name" }!!
+            nameColumn.type shouldBe "VARCHAR(100)"
+            nameColumn.nullable shouldBe false
+        }
+
+        test("should extract primary key constraints from CreateTable") {
+            val columns = listOf(
+                Column.build(
+                    name = "id",
+                    type = "INTEGER",
+                    columnConstraint = ColumnConstraint(primaryKey = true, nullable = false)
+                )
+            )
+
+            val changes = listOf(
+                CreateTable(
+                    tableName = "users",
+                    columns = columns
+                )
+            )
+
+            val result = generator.generateData(changes)
+
+            result.constraints shouldHaveSize 1
+            val constraint = result.constraints.first()
+            constraint.name shouldBe "users_id_pk"
+            constraint.type shouldBe ConstraintType.PRIMARY_KEY
+            constraint.tableName shouldBe "users"
+            constraint.columns shouldBe listOf("id")
+        }
+
+        test("should extract index information from AddIndex change") {
+            val changes = listOf(
+                AddIndex(
+                    indexName = "idx_user_email",
+                    tableName = "users",
+                    columnNames = listOf("email"),
+                    unique = true
+                )
+            )
+
+            val result = generator.generateData(changes)
+
+            result.indexes shouldHaveSize 1
+            val index = result.indexes.first()
+            index.name shouldBe "idx_user_email"
+            index.tableName shouldBe "users"
+            index.columns shouldBe listOf("email")
+            index.unique shouldBe true
+        }
+
+        test("should extract foreign key constraints from AddForeignKey change") {
+            val changes = listOf(
+                AddForeignKey(
+                    constraintName = "fk_user_department",
+                    tableName = "users",
+                    columnNames = listOf("department_id"),
+                    referencedTableName = "departments",
+                    referencedColumnNames = listOf("id"),
+                    onDelete = ForeignKeyAction.CASCADE,
+                    onUpdate = ForeignKeyAction.RESTRICT
+                )
+            )
+
+            val result = generator.generateData(changes)
+
+            result.constraints shouldHaveSize 1
+            val constraint = result.constraints.first()
+            constraint.name shouldBe "fk_user_department"
+            constraint.type shouldBe ConstraintType.FOREIGN_KEY
+            constraint.tableName shouldBe "users"
+            constraint.columns shouldBe listOf("department_id")
+            constraint.referencedTable shouldBe "departments"
+            constraint.referencedColumns shouldBe listOf("id")
+
+            val metadata = constraint.metadata
+            metadata["onDelete"] shouldBe ForeignKeyAction.CASCADE
+            metadata["onUpdate"] shouldBe ForeignKeyAction.RESTRICT
+        }
+
+        test("should extract unique constraints from AddUniqueConstraint change") {
+            val changes = listOf(
+                AddUniqueConstraint(
+                    constraintName = "uk_user_email",
+                    tableName = "users",
+                    columnNames = listOf("email")
+                )
+            )
+
+            val result = generator.generateData(changes)
+
+            result.constraints shouldHaveSize 1
+            val constraint = result.constraints.first()
+            constraint.name shouldBe "uk_user_email"
+            constraint.type shouldBe ConstraintType.UNIQUE
+            constraint.tableName shouldBe "users"
+            constraint.columns shouldBe listOf("email")
+        }
+
+        test("should extract not null constraints from AddNotNullConstraint change") {
+            val changes = listOf(
+                AddNotNullConstraint(
+                    tableName = "users",
+                    columnName = "name",
+                    columnDataType = "VARCHAR(100)",
+                    defaultValue = "Unknown"
+                )
+            )
+
+            val result = generator.generateData(changes)
+
+            result.constraints shouldHaveSize 1
+            val constraint = result.constraints.first()
+            constraint.name shouldBe "users_name_not_null"
+            constraint.type shouldBe ConstraintType.NOT_NULL
+            constraint.tableName shouldBe "users"
+            constraint.columns shouldBe listOf("name")
+
+            val metadata = constraint.metadata
+            metadata["columnDataType"] shouldBe "VARCHAR(100)"
+            metadata["defaultValue"] shouldBe "Unknown"
+        }
+
+        test("should extract sequence information from CreateSequence change") {
+            val changes = listOf(
+                CreateSequence(
+                    sequenceName = "user_id_seq",
+                    dataType = "BIGINT",
+                    startValue = 1,
+                    incrementBy = 1,
+                    minValue = 1,
+                    maxValue = Long.MAX_VALUE,
+                    cycle = false,
+                    cacheSize = 50
+                )
+            )
+
+            val result = generator.generateData(changes)
+
+            result.sequences shouldHaveSize 1
+            val sequence = result.sequences.first()
+            sequence.name shouldBe "user_id_seq"
+            sequence.dataType shouldBe "BIGINT"
+            sequence.startValue shouldBe 1
+            sequence.incrementBy shouldBe 1
+            sequence.minValue shouldBe 1
+            sequence.maxValue shouldBe Long.MAX_VALUE
+            sequence.cycle shouldBe false
+
+            val metadata = sequence.metadata
+            metadata["cacheSize"] shouldBe 50L
+        }
+
+        test("should handle AddColumn changes for existing tables") {
+            val changes = listOf(
+                CreateTable(
+                    tableName = "users",
+                    columns = listOf(
+                        Column.build(name = "id", type = "INTEGER")
+                    )
+                ),
+                AddColumn(
+                    tableName = "users",
+                    column = Column.build(
+                        name = "email",
+                        type = "VARCHAR(255)",
+                        columnConstraint = ColumnConstraint(nullable = false)
+                    )
+                )
+            )
+
+            val result = generator.generateData(changes)
+
+            result.tables shouldHaveSize 1
+            val table = result.tables.first()
+            table.name shouldBe "users"
+            table.columns shouldHaveSize 2
+
+            val columns = table.columns.map { it.name }
+            columns shouldContain "id"
+            columns shouldContain "email"
+        }
+
+        test("should generate metadata with change statistics") {
+            val changes = listOf(
+                CreateTable(tableName = "users", columns = emptyList()),
+                CreateTable(tableName = "departments", columns = emptyList()),
+                AddIndex(indexName = "idx_test", tableName = "users", columnNames = listOf("id")),
+                CreateSequence(sequenceName = "test_seq")
+            )
+
+            val result = generator.generateData(changes)
+
+            result.metadata["totalChanges"] shouldBe 4
+            val changeTypeCounts = result.metadata["changeTypeCounts"] as Map<*, *>
+            changeTypeCounts["CreateTable"] shouldBe 2
+            changeTypeCounts["AddIndex"] shouldBe 1
+            changeTypeCounts["CreateSequence"] shouldBe 1
+            result.metadata["generatedAt"].shouldBeInstanceOf<Long>()
+        }
+
+        test("should build column metadata from Column properties") {
+            val column = Column.build(
+                name = "test_column",
+                type = "INTEGER",
+                autoIncrement = true,
+                identityGeneration = "by default",
+                startValue = 10,
+                incrementBy = 2,
+                cycle = true
+            )
+
+            val changes = listOf(
+                CreateTable(
+                    tableName = "test_table",
+                    columns = listOf(column)
+                )
+            )
+
+            val result = generator.generateData(changes)
+
+            val table = result.tables.first()
+            val columnInfo = table.columns.first()
+            val metadata = columnInfo.metadata
+
+            metadata["identityGeneration"] shouldBe Column.IdentityGeneration.BY_DEFAULT
+            metadata["startValue"] shouldBe 10L
+            metadata["incrementBy"] shouldBe 2L
+            metadata["cycle"] shouldBe true
+        }
+    }
+})

--- a/core/src/test/kotlin/momosetkn/maigreko/data/BaseRecordDataGeneratorSpec.kt
+++ b/core/src/test/kotlin/momosetkn/maigreko/data/BaseRecordDataGeneratorSpec.kt
@@ -1,0 +1,218 @@
+package momosetkn.maigreko.data
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.random.Random
+
+class BaseRecordDataGeneratorSpec : FunSpec({
+
+    context("BaseRecordDataGenerator") {
+        val generator = BaseRecordDataGenerator()
+
+        test("should generate records for a simple table") {
+            val table = TableInfo(
+                name = "users",
+                columns = listOf(
+                    ColumnInfo(name = "id", type = "INTEGER", autoIncrement = true, nullable = false),
+                    ColumnInfo(name = "name", type = "VARCHAR(100)", nullable = false),
+                    ColumnInfo(name = "email", type = "VARCHAR(255)", nullable = false)
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 5, seed = 12345)
+            val result = generator.generateRecords(table, config)
+
+            result.tableName shouldBe "users"
+            result.records shouldHaveSize 5
+
+            val firstRecord = result.records.first()
+            firstRecord.keys shouldHaveSize 3
+            firstRecord["id"] shouldBe 1L
+            firstRecord["name"] shouldNotBe null
+            firstRecord["email"] shouldNotBe null
+        }
+
+        test("should handle nullable columns") {
+            val table = TableInfo(
+                name = "products",
+                columns = listOf(
+                    ColumnInfo(name = "id", type = "INTEGER", autoIncrement = true, nullable = false),
+                    ColumnInfo(name = "description", type = "TEXT", nullable = true)
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 50, seed = 12345)
+            val result = generator.generateRecords(table, config)
+
+            result.records shouldHaveSize 50
+
+            // Check that some records have null values for nullable columns
+            val nullDescriptions = result.records.count { it["description"] == null }
+            nullDescriptions shouldNotBe 0 // Should have some null values
+        }
+
+        test("should handle default values") {
+            val table = TableInfo(
+                name = "settings",
+                columns = listOf(
+                    ColumnInfo(name = "id", type = "INTEGER", autoIncrement = true, nullable = false),
+                    ColumnInfo(name = "active", type = "BOOLEAN", defaultValue = true, nullable = false)
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 10, seed = 12345)
+            val result = generator.generateRecords(table, config)
+
+            result.records shouldHaveSize 10
+
+            // Some records should use the default value
+            val defaultValues = result.records.count { it["active"] == true }
+            defaultValues shouldNotBe 0 // Should have some default values
+        }
+
+        test("should generate appropriate values for different data types") {
+            val table = TableInfo(
+                name = "test_types",
+                columns = listOf(
+                    ColumnInfo(name = "int_col", type = "INTEGER", nullable = false),
+                    ColumnInfo(name = "bigint_col", type = "BIGINT", nullable = false),
+                    ColumnInfo(name = "varchar_col", type = "VARCHAR(50)", nullable = false),
+                    ColumnInfo(name = "decimal_col", type = "DECIMAL(10,2)", nullable = false),
+                    ColumnInfo(name = "date_col", type = "DATE", nullable = false),
+                    ColumnInfo(name = "timestamp_col", type = "TIMESTAMP", nullable = false),
+                    ColumnInfo(name = "bool_col", type = "BOOLEAN", nullable = false),
+                    ColumnInfo(name = "uuid_col", type = "UUID", nullable = false)
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 1, seed = 12345)
+            val result = generator.generateRecords(table, config)
+
+            result.records shouldHaveSize 1
+            val record = result.records.first()
+
+            record["int_col"].shouldBeInstanceOf<Int>()
+            record["bigint_col"].shouldBeInstanceOf<Long>()
+            record["varchar_col"].shouldBeInstanceOf<String>()
+            record["decimal_col"].shouldBeInstanceOf<java.math.BigDecimal>()
+            record["date_col"].shouldBeInstanceOf<java.sql.Date>()
+            record["timestamp_col"].shouldBeInstanceOf<java.sql.Timestamp>()
+            record["bool_col"].shouldBeInstanceOf<Boolean>()
+            record["uuid_col"].shouldBeInstanceOf<String>()
+        }
+
+        test("should use custom value generators when provided") {
+            val table = TableInfo(
+                name = "custom_test",
+                columns = listOf(
+                    ColumnInfo(name = "id", type = "INTEGER"),
+                    ColumnInfo(name = "custom_field", type = "VARCHAR(100)")
+                )
+            )
+
+            val customGenerator = object : ValueGenerator {
+                override fun generate(columnInfo: ColumnInfo, context: Map<String, Any?>): Any? {
+                    return "custom_value_${context.size}"
+                }
+            }
+
+            val config = RecordGenerationConfig(
+                recordsPerTable = 3,
+                customGenerators = mapOf("custom_field" to customGenerator)
+            )
+
+            val result = generator.generateRecords(table, config)
+
+            result.records shouldHaveSize 3
+            result.records.forEach { record ->
+                val customValue = record["custom_field"] as String
+                customValue shouldBe "custom_value_1" // context size is always 1 (id field)
+            }
+        }
+
+        test("should generate realistic email addresses for email fields") {
+            val table = TableInfo(
+                name = "users",
+                columns = listOf(
+                    ColumnInfo(name = "email", type = "VARCHAR(255)", nullable = false)
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 5, seed = 12345)
+            val result = generator.generateRecords(table, config)
+
+            result.records shouldHaveSize 5
+            result.records.forEach { record ->
+                val email = record["email"]
+                email shouldNotBe null
+                if (email is String) {
+                    email.contains("@") shouldBe true
+                    email.contains(".") shouldBe true
+                }
+            }
+        }
+
+        test("should handle multiple tables with relationships") {
+            val userTable = TableInfo(
+                name = "users",
+                columns = listOf(
+                    ColumnInfo(name = "id", type = "INTEGER", autoIncrement = true, nullable = false),
+                    ColumnInfo(name = "name", type = "VARCHAR(100)", nullable = false)
+                )
+            )
+
+            val orderTable = TableInfo(
+                name = "orders",
+                columns = listOf(
+                    ColumnInfo(name = "id", type = "INTEGER", autoIncrement = true, nullable = false),
+                    ColumnInfo(name = "user_id", type = "INTEGER", nullable = false),
+                    ColumnInfo(name = "amount", type = "DECIMAL(10,2)", nullable = false)
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 3, seed = 12345)
+            val result = generator.generateRecords(listOf(userTable, orderTable), config)
+
+            result.size shouldBe 2
+            result["users"]!!.records shouldHaveSize 3
+            result["orders"]!!.records shouldHaveSize 3
+        }
+
+        test("should respect string length constraints") {
+            val table = TableInfo(
+                name = "short_strings",
+                columns = listOf(
+                    ColumnInfo(name = "short_field", type = "VARCHAR(10)")
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 5, seed = 12345)
+            val result = generator.generateRecords(table, config)
+
+            result.records shouldHaveSize 5
+            result.records.forEach { record ->
+                val shortValue = record["short_field"] as String
+                shortValue.length shouldBe 10 // Should respect max length
+            }
+        }
+
+        test("should include metadata in generated record data") {
+            val table = TableInfo(
+                name = "test_table",
+                columns = listOf(
+                    ColumnInfo(name = "id", type = "INTEGER", autoIncrement = true)
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 5)
+            val result = generator.generateRecords(table, config)
+
+            result.metadata["recordCount"] shouldBe 5
+            result.metadata["config"] shouldBe config
+            result.metadata.containsKey("generatedAt") shouldBe true
+        }
+    }
+})

--- a/core/src/test/kotlin/momosetkn/maigreko/data/RecordDataGeneratorFactorySpec.kt
+++ b/core/src/test/kotlin/momosetkn/maigreko/data/RecordDataGeneratorFactorySpec.kt
@@ -1,0 +1,92 @@
+package momosetkn.maigreko.data
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class RecordDataGeneratorFactorySpec : FunSpec({
+
+    context("RecordDataGeneratorFactory") {
+
+        test("should create base implementation when no specific builders found") {
+            val generator = RecordDataGeneratorFactory.createFirst()
+            generator.shouldBeInstanceOf<BaseRecordDataGenerator>()
+        }
+
+        test("should generate records from DatabaseData") {
+            val databaseData = DatabaseData(
+                sourceChanges = emptyList(),
+                tables = listOf(
+                    TableInfo(
+                        name = "test_table",
+                        columns = listOf(
+                            ColumnInfo(name = "id", type = "INTEGER", autoIncrement = true, nullable = false),
+                            ColumnInfo(name = "name", type = "VARCHAR(100)", nullable = false)
+                        )
+                    )
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 3, seed = 12345)
+            val result = RecordDataGeneratorFactory.generateRecords(databaseData, config)
+
+            result.size shouldBe 1
+            val tableRecords = result["test_table"]!!
+            tableRecords.tableName shouldBe "test_table"
+            tableRecords.records.size shouldBe 3
+
+            val firstRecord = tableRecords.records.first()
+            firstRecord["id"] shouldBe 1L
+            firstRecord["name"] shouldNotBe null
+        }
+
+        test("should handle empty DatabaseData") {
+            val databaseData = DatabaseData(
+                sourceChanges = emptyList(),
+                tables = emptyList()
+            )
+
+            val result = RecordDataGeneratorFactory.generateRecords(databaseData)
+            result.size shouldBe 0
+        }
+
+        test("should handle multiple tables in DatabaseData") {
+            val databaseData = DatabaseData(
+                sourceChanges = emptyList(),
+                tables = listOf(
+                    TableInfo(
+                        name = "users",
+                        columns = listOf(
+                            ColumnInfo(name = "id", type = "INTEGER", autoIncrement = true),
+                            ColumnInfo(name = "email", type = "VARCHAR(255)")
+                        )
+                    ),
+                    TableInfo(
+                        name = "orders",
+                        columns = listOf(
+                            ColumnInfo(name = "id", type = "INTEGER", autoIncrement = true),
+                            ColumnInfo(name = "total", type = "DECIMAL(10,2)")
+                        )
+                    )
+                )
+            )
+
+            val config = RecordGenerationConfig(recordsPerTable = 2, seed = 54321)
+            val result = RecordDataGeneratorFactory.generateRecords(databaseData, config)
+
+            result.size shouldBe 2
+            result["users"]!!.records.size shouldBe 2
+            result["orders"]!!.records.size shouldBe 2
+
+            // Verify data types
+            val userRecord = result["users"]!!.records.first()
+            val orderRecord = result["orders"]!!.records.first()
+
+            userRecord["id"].shouldBeInstanceOf<Long>()
+            userRecord["email"].shouldBeInstanceOf<String>()
+            orderRecord["id"].shouldBeInstanceOf<Long>()
+            orderRecord["total"].shouldBeInstanceOf<java.math.BigDecimal>()
+        }
+    }
+})


### PR DESCRIPTION
- Introduced foundational interfaces and implementations for database data generation (`DataGenerator`) and record data generation (`RecordDataGenerator`).
- Created base implementations for processing schema changes (`BaseDataGenerator`) and generating sample records (`BaseRecordDataGenerator`).
- Added data models (`DatabaseData`, `TableInfo`, `RecordData`) to represent database structures and record generation configurations.
- Enabled extensibility for database-specific logic using `RecordDataGeneratorBuilder` and `RecordDataGeneratorFactory`.